### PR TITLE
Fix os config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+.idea/
+.vscode/
+
 seeds-cloudimg.iso
 seeds-flat.iso
 seeds-lvm.iso

--- a/packer/ubuntu/Makefile
+++ b/packer/ubuntu/Makefile
@@ -12,6 +12,9 @@ lint:
 format:
 	packer fmt .
 
+seeds-flat.iso: user-data-flat meta-data
+	cloud-localds $@ $^
+
 OVMF_VARS.fd: /usr/share/OVMF/OVMF_VARS.fd
 	cp -v $< $@
 

--- a/packer/ubuntu/user-data-cloudimg
+++ b/packer/ubuntu/user-data-cloudimg
@@ -8,17 +8,9 @@ users:
   # - name: example_naps_user
   #   groups: sudo
   #   lock_passwd: false
-  #   hashed_passwd: '$6$Ef7zoCrHuodIQ4r2$gbV54qMmRjUwTOlp0J9VYWjzXZRaA7XNWWVbn0cVahk1nvFpVCcBE4qs0HwfCx22WmIZ8BE575zfsrR9UDKSL0'
+  #   hashed_passwd: '$6$MUHLpqkVw07bh9zm$R6/oe/12Bq0kBmed.l9DUKFy/69I2/POprpE.lfl9lgWmUZ2o.f0.PgYt34IBguWHCkOAw1lKjb6L7zTsjFPZ0'
+  #   # mkpasswd -m sha-512 --stdin <<< "REDACTED"
   #   ssh_redirect_user: false
-
-system_info:
-  default_user:
-    # change if desired
-    name: ubuntu
-
-ssh_pwauth: true
-password: '$6$RC4gvO5EOk2jMOlt$LY9nJ3P9nh.1xrJAIhOYMORX7W1gX5j2D1XJxY8NmaQQHOjGib1CWtFoYTiFwdYnCIsKCuKMluLrVsU6puzp60'
-# mkpasswd -m sha-512 --stdin <<< "REDACTED"
 
 ssh_pwauth: True
 disable_root: false

--- a/packer/ubuntu/user-data-cloudimg
+++ b/packer/ubuntu/user-data-cloudimg
@@ -11,11 +11,34 @@ users:
   #   hashed_passwd: '$6$Ef7zoCrHuodIQ4r2$gbV54qMmRjUwTOlp0J9VYWjzXZRaA7XNWWVbn0cVahk1nvFpVCcBE4qs0HwfCx22WmIZ8BE575zfsrR9UDKSL0'
   #   ssh_redirect_user: false
 
+system_info:
+  default_user:
+    # change if desired
+    name: ubuntu
+
+ssh_pwauth: true
+password: '$6$RC4gvO5EOk2jMOlt$LY9nJ3P9nh.1xrJAIhOYMORX7W1gX5j2D1XJxY8NmaQQHOjGib1CWtFoYTiFwdYnCIsKCuKMluLrVsU6puzp60'
+# mkpasswd -m sha-512 --stdin <<< "REDACTED"
 
 ssh_pwauth: True
 disable_root: false
 preserve_hostname: true
 write_files:
+  - path: /etc/sysctl.d/99-k8s.conf
+    permissions: 0644
+    content: |
+      vm.max_map_count=1524288
+      fs.file-max=1000000
+      fs.inotify.max_user_instances=8192
+  
+  - path: /etc/security/limits.d/99-k8s.conf
+    permissions: 0644
+    content: |
+      * hard nofile 1000000
+      * soft nofile 1000000
+      * hard nproc 8192
+      * soft nproc 8192
+
   - path: /opt/setup.sh
     permissions: 0770
     content: |
@@ -34,17 +57,7 @@ write_files:
       lvresize -rl +100%FREE /dev/vgroot/lvroot
 
       echo "Install iptables (required for nginx ingress controller) (all nodes)"
-      apt install iptables
-
-      echo "Set up elastic limits (all nodes)"
-      sysctl -w vm.max_map_count=1524288
-      sysctl -w fs.file-max=1000000
-      ulimit -n 1000000
-      ulimit -u 8192
-      sysctl --load
-      swapoff -a
-      sysctl fs.inotify.max_user_instances=8192
-      sysctl -p
+      apt install iptables -y
 
       echo "Set up Longhorn dependencies (all nodes)"
       apt install open-iscsi nfs-common -y
@@ -67,6 +80,10 @@ runcmd:
   - systemctl restart ssh
   - curl -sfL https://get.rke2.io | INSTALL_RKE2_VERSION="v1.26.3+rke2r1" sh -
   - mkdir -p /etc/rancher/rke2
+  - swapoff -a
+  - sed -e '/swap/ s/^#*/#/' -i /etc/fstab
+  - systemctl mask swap.target
+  - sysctl --load
 bootcmd:
   - mkdir /run/packer_backup
   - mkdir /run/packer_backup/etc

--- a/packer/ubuntu/user-data-cloudimg
+++ b/packer/ubuntu/user-data-cloudimg
@@ -20,7 +20,6 @@ write_files:
     permissions: 0644
     content: |
       vm.max_map_count=1524288
-      fs.file-max=1000000
       fs.inotify.max_user_instances=8192
   
   - path: /etc/security/limits.d/99-k8s.conf

--- a/packer/ubuntu/user-data-cloudimg
+++ b/packer/ubuntu/user-data-cloudimg
@@ -83,7 +83,7 @@ runcmd:
   - swapoff -a
   - sed -e '/swap/ s/^#*/#/' -i /etc/fstab
   - systemctl mask swap.target
-  - sysctl --load
+  - sysctl --system
 bootcmd:
   - mkdir /run/packer_backup
   - mkdir /run/packer_backup/etc

--- a/packer/ubuntu/user-data-flat
+++ b/packer/ubuntu/user-data-flat
@@ -1,0 +1,23 @@
+#cloud-config
+autoinstall:
+  version: 1
+  identity:
+    hostname: ubuntu
+    username: ubuntu
+    password: "$6$canonical.$0zWaW71A9ke9ASsaOcFTdQ2tx1gSmLxMPrsH0rF0Yb.2AEKNPV1lrF94n6YuPJmnUy2K2/JSDtxuiBDey6Lpa/"
+  keyboard:
+    layout: us
+    variant: ''
+  ssh:
+    install-server: true
+  storage:
+    grub:
+      update_nvram: true
+    swap:
+      size: 0
+    layout:
+      name: direct
+  late-commands:
+    - echo 'ubuntu ALL=(ALL) NOPASSWD:ALL' > /target/etc/sudoers.d/ubuntu
+  package_update: true
+  package_upgrade: true


### PR DESCRIPTION
## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Description

This PR fixes a misconfiguration of swap and file system limits needed for kubernetes. Currently the configuration is only changed for the first boot. If the machine is rebooted the limits and swap configuration are lost. This change corrects that by adding the configuration into the  appropriate`sysctl` and `limits` configuration files.

The PR adds a make target for building the image seed from the `user-data-flat` file. These files were missing and likely got removed by accident on a previous checkin.

# How Has This Been Tested?

The image was built, uploaded to MAAS and applied to a new system. Settings were checked using the following bash script after the first boot and after rebooting the system.
```shell
#!/bin/bash

# Verify sysctl parameters
echo "vm.max_map_count:"
sysctl vm.max_map_count

echo "fs.file-max:"
sysctl fs.file-max

# Verify ulimit settings
echo "Maximum number of open file descriptors:"
ulimit -n

echo "Maximum number of user processes:"
ulimit -u

# Verify swap status
echo "Swap status:"
swapon --show
echo "If the output is empty, it means swap is not enabled."

# Verify inotify max_user_instances setting
echo "fs.inotify.max_user_instances:"
sysctl fs.inotify.max_user_instances

```

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added a plain language explanation of the changes to the Unreleased section of the CHANGELOG.md file

